### PR TITLE
Add link to demos on front page

### DIFF
--- a/src/pages/index.eno
+++ b/src/pages/index.eno
@@ -32,6 +32,8 @@ Málaga: 36.721447, -4.421291
 Springfield: 38.790312, -77.186418
 ```
 
+[Try an interactive demo!](/demo)
+
 Language Overview:
 - As fast to write and edit as it probably gets
 - Intuitive and simple - easy to use for non-programmers too


### PR DESCRIPTION
Hello! Thanks for making Eno.

I cloned the repo because I wanted to try adding a live, interactive, in-browser demo. I found that there already was a page for that, but I didn't know it existed.

This PR adds a link to the live Eno demo so other visitors can find it from the front page.